### PR TITLE
Change air quality index value to integer

### DIFF
--- a/custom_components/worlds_air_quality_index/const.py
+++ b/custom_components/worlds_air_quality_index/const.py
@@ -25,7 +25,7 @@ STATION_ID = "Station ID"
 DEFAULT_NAME = 'waqi1'
 
 SENSORS = {
-    'aqi': ['Air Quality Index', None, 'mdi:leaf', SensorDeviceClass.AQI],
+    'aqi': ['Air Quality Index', ' ', 'mdi:leaf', SensorDeviceClass.AQI],
     'pm10': ['Particulate matter (PM10)', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, 'mdi:skull-outline', SensorDeviceClass.PM10],
     'pm25': ['Particulate matter (PM2,5)', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, 'mdi:skull-outline', SensorDeviceClass.PM25],
     'co': ['Carbon monoxide (CO)', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, 'mdi:molecule-co', SensorDeviceClass.CO],

--- a/custom_components/worlds_air_quality_index/sensor.py
+++ b/custom_components/worlds_air_quality_index/sensor.py
@@ -169,7 +169,11 @@ class WorldsAirQualityIndexSensor(SensorEntity):
         self._updateLastTime = self._requester.GetUpdateLastTime()
 
         if self._resType == 'aqi':
-            self._state = float(_data["data"]["aqi"])
+            if _data["data"]["aqi"] == "-":
+                _LOGGER.warning("aqi value from json waqi api was undefined ('-' value)")
+                self._state = 0
+            else:
+                self._state = int(_data["data"]["aqi"])
         elif self._resType == 't':
             if self._tempUnit == TEMP_FAHRENHEIT:
                 self._state = 9.0 * float(_data["data"]["iaqi"]['t']["v"]) / 5.0 + 32.0


### PR DESCRIPTION
* Change the unit type of the aqi sensor to ' ' and convert its value to int instead of float
* Prevent a component failure when aqi value returned by waqi API is set to '-'. It is not expected according to api documentation but happened the 2022-08-14 during 90 mn for Paris station. In this case I forced aqi sensor value to 0. Also note that the waqi website displayed a historical value and therefore didn't not have this bugged value. 
* Add a warning message in homeassistant log when '-' aqi value is encountered