### PR TITLE
2023.3+: await async_forward_entry_setups

### DIFF
--- a/custom_components/worlds_air_quality_index/__init__.py
+++ b/custom_components/worlds_air_quality_index/__init__.py
@@ -27,7 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up World's Air Quality Index from a config entry."""
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(update_listener))
     return True
 


### PR DESCRIPTION
As of 2023.1 we're getting this deprecation warning:

2023-02-08 17:43:00.966 WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_setup_platforms instead of awaiting async_forward_entry_setups; this will fail in version 2023.3. Please report issue to the custom integration author for worlds_air_quality_index using this method at custom_components/worlds_air_quality_index/__init__.py, line 30: hass.config_entries.async_setup_platforms(entry, PLATFORMS)
